### PR TITLE
Update links to michi-c and michi-c2

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,9 @@ to inspire is rewrite of the same algorithm in different, faster programming
 languages; hopefully seeing a done real-world thing is easier than developing
 it from scratch.  What about a Go engine in the Go language?)
 
-**michi-c** is such a rewrite of Michi, in C++.  It seems to play even with
-GNUGo when given 3.3s/move: https://github.com/db3108/michi-c
+**michi-c** is such a rewrite of Michi, in plain C.  It seems to play even with
+GNUGo when given 3.3s/move: https://github.com/db3108/michi-c2.
+
+Note: there is a clone version of the michi python code (slower than michi-c2) 
+that is available at https://github.com/db3108/michi-c. 
+This simpler version can be read in parallel with the michi.py python code.


### PR DESCRIPTION
Hi Petr,

Thank you for the link to michi-c.

I have added in the README some (I hope useful) information about the 2 projects michi-c and michi-c2.
- michi-c aim is to stay as simple as possible and as close as possible to the michi.py code.
- michi-c2 aim is to try to get the best possible performance from the algorithms you put in michi.py (not changing the algorithms but making the operations faster. I hope to be able to add soon parallelization with Pthreads).
